### PR TITLE
Remove copyrighted Apple icon

### DIFF
--- a/clean_packages.js
+++ b/clean_packages.js
@@ -1,0 +1,9 @@
+fs = require('fs');
+filename='./node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app/Contents/Resources/Terminal.icns';
+if (fs.existsSync(filename)) {
+	fs.writeFile(filename, '', function (err,data) {
+	  if (err) {
+	    return console.log(err);
+	  }
+	});
+}

--- a/clean_packages.js
+++ b/clean_packages.js
@@ -1,9 +1,0 @@
-fs = require('fs');
-filename='./node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app/Contents/Resources/Terminal.icns';
-if (fs.existsSync(filename)) {
-	fs.writeFile(filename, '', function (err,data) {
-	  if (err) {
-	    return console.log(err);
-	  }
-	});
-}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "postinstall": "node clean_packages.js"
+    "postinstall": "node script/postinstall.js"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build"
+    "build": "react-scripts build",
+    "postinstall": "node clean_packages.js"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -1,0 +1,17 @@
+/*
+ * react-scripts depends on modules that depend on node-notifier. The problem is that the latter include Terminal.icns
+ * for its Mac OS X notification native app, which is copyrighted by Apple. There has been an open issue since 2005
+ * with no proper solution: https://github.com/mikaelbr/node-notifier/issues/71
+ * We have therefore decided to remove that icon at install time.
+ *
+ * Errors in this script should be silently ignored in case that node-notifier suddenly decides to fix the problem.
+ */
+fs = require('fs');
+filename='./node_modules/node-notifier/vendor/mac.noindex/terminal-notifier.app/Contents/Resources/Terminal.icns';
+if (fs.existsSync(filename)) {
+	fs.writeFile(filename, '', function (err,data) {
+	  if (err) {
+	    return console.log(err);
+	  }
+	});
+}


### PR DESCRIPTION
The icon was imported through react-scripts that imported react-reports that uses node-notifier that in turn uses terminal-notifier, but not as a dependency, as an included binary. That terminal-notifier has not been updated in over 8 years and is actually not necessary for our use. Making a fork of react-scripts is a poor idea as it would cut us from security updates.
So here, we are simply removing the icon at install time.
If the file is not present, the hook silently ignores it.

This addresses a long standing issue of being the only copyright issue in the OpenIMIS codebase.