### PR TITLE
OSD-179: updated version of fe on package.json to display proper version on main page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openimis/fe",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "AGPL-3.0-only",
   "proxy": "http://localhost:8000",
   "homepage": "http://localhost:3000/front",


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OSD-179
Related TICKET - part of this ticket: https://openimis.atlassian.net/browse/OP-785
![Screenshot from 2022-05-27 10-32-13](https://user-images.githubusercontent.com/52816247/170664757-819fd136-1507-41a2-a5fc-32568c11cf2b.png)

The issue was that version in package.json was't set up properly. It was still '1.3.0'