### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Another important point is NOT TO HAVE in backend db table user_Core (managed by
 This issue is related to the link between userCore and tblUser tables.</td></tr></table>
 
 - clone this repo (creates the `openimis-fe_js` directory)
-- install node
+- install node (node V16.x)
 - install yarn
 - within `openimis-fe_js` directory
   - generate the openIMIS modules dependencies and locales (from openimis.json config): `yarn load-config` or `yarn load-config openimis.json`


### PR DESCRIPTION
Front End seems not compatible with current node version (18.x) version on MacOS X
Yarn compilation is OK , but gives a Gateway Error on the browser that comes from a proxy error (proxy request on localhost:8000 give a ECONNREFUSED)