### PR TITLE
OTC-748 Added support for custom api url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# The root of backend api. Have to match the SITE_ROOT value on openIMIS backend
+REACT_APP_API_URL=api

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/modules.js
 src/locales.js
 .idea
 yarn.lock
+.env

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -6,12 +6,18 @@ module.exports = function (app) {
   if (process.env.REMOTE_USER) {
     headers["Remote-User"] = process.env.REMOTE_USER;
   }
+
+  let baseApiUrl = process.env.REACT_APP_API_URL ?? '/api';
+  if (baseApiUrl.indexOf('/') !== 0) {
+    baseApiUrl = `/${baseApiUrl}`;
+  }
+
   app.use(
-    "/api",
+    baseApiUrl,
     createProxyMiddleware({
       target: pkg.proxy,
       changeOrigin: true,
-      headers: headers,
+      headers: headers
     }),
   );
 };


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-748](https://openimis.atlassian.net/browse/OTC-748)

Changes:
- Added an option to overrige default /api backend proxy with a custom one with REACT_APP_API_URL. This is done at build time and cannot be updated at runtime. 
- Added `.env` to `.gitignore`
- Added `.env.example`