### PR TITLE
OP-781: add flex tooltip container to theme

### DIFF
--- a/src/helpers/theme.js
+++ b/src/helpers/theme.js
@@ -183,6 +183,18 @@ const theme = createTheme({
     },
     secondaryButton: {},
   },
+  tooltipContainer: {
+    position: 'fixed',
+    bottom: 15,
+    right: 8,
+    zIndex: 2000,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+  },
+  flexTooltip: {
+    marginBottom: 5,
+  },
   fab: {
     position: "fixed",
     bottom: 20,


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OP-781

This PR add css for displaying multiple fab tooltips.

Related to: 
https://github.com/openimis/openimis-fe-claim_js/pull/128