### PR TITLE
OP-1847: improve modules js generation

### DIFF
--- a/modules-config.js
+++ b/modules-config.js
@@ -45,15 +45,21 @@ export const packages = [
 `);
 
   stream.write(`
-export function loadModules (cfg = {}) {
-  return [
-    ${modules
-      .map(
-        ({ name, logicalName, moduleName }) =>
-          `require("${moduleName}").${name ?? "default"}(cfg["${logicalName}"] || {})`,
-      )
-      .join(",\n    ")}
-  ];\n
+export function loadModules(cfg = {}) {
+  const loadedModules = [];
+${modules
+.map(({ name, logicalName, moduleName }) => {
+return `
+  try {
+    loadedModules.push(require("${moduleName}").${name ?? "default"}(cfg["${logicalName}"] || {}));
+  } catch (error) {
+    alert(\`Failed to load module "${moduleName}". More details can be found in the developer console. Look for: \${error}\`);
+    console.error(error);
+  }
+`;
+})
+.join("")}
+  return loadedModules;
 }
 `);
 

--- a/openimis-config.js
+++ b/openimis-config.js
@@ -45,15 +45,21 @@ export const packages = [
 `);
 
   stream.write(`
-export function loadModules (cfg = {}) {
-  return [
-    ${modules
-      .map(
-        ({ name, logicalName, moduleName }) =>
-          `require("${moduleName}").${name ?? "default"}(cfg["${logicalName}"] || {})`,
-      )
-      .join(",\n    ")}
-  ];\n
+export function loadModules(cfg = {}) {
+  const loadedModules = [];
+${modules
+.map(({ name, logicalName, moduleName }) => {
+return `
+  try {
+    loadedModules.push(require("${moduleName}").${name ?? "default"}(cfg["${logicalName}"] || {}));
+  } catch (error) {
+    alert(\`Failed to load module "${moduleName}". More details can be found in the developer console. Look for: \${error}\`);
+    console.error(error);
+  }
+`;
+})
+.join("")}
+  return loadedModules;
 }
 `);
 


### PR DESCRIPTION
[OP-1847](https://openimis.atlassian.net/browse/OP-1847)

Changes:
- Include a try-catch block around each module loading operation.
- If there is an error, it will trigger an alert informing about the failure and log the error details to the console.
- The error will be alerted to the user, but it won't halt the loading process of other modules.

[OP-1847]: https://openimis.atlassian.net/browse/OP-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ