### PR TITLE
OSB-20: added getMenuEntries - required in openimis-fe-core

### DIFF
--- a/src/ModulesManager.js
+++ b/src/ModulesManager.js
@@ -86,6 +86,18 @@ class ModulesManager {
     const moduleCfg = this.cfg[module] || {};
     return moduleCfg[key] !== undefined ? moduleCfg[key] : defaultValue;
   }
+
+  getMenuEntries() {
+    return this.modules.reduce((menuEntries, module) => {
+      const mainMenuKeys = Object.keys(module).filter(
+        (key) => key.includes(".MainMenu") && key !== "core.MainMenu"
+      );
+      mainMenuKeys.forEach((key) => {
+        menuEntries.push(...ensureArray(module[key]));
+      });
+      return menuEntries;
+    }, []);
+  }
 }
 
 export default ModulesManager;


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OSB-20

Changes related to OSB-7 - MainMenu entries refactor - on Moldova we can keep as it is (no config for 'Menus'), but assembly needs this change. 