### PR TITLE
OS-102: added strong DH parameters and generate them on docker init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY --from=build-stage /etc/ssl/private/ /etc/nginx/ssl/live/host
 
 COPY ./conf /conf
 COPY script/entrypoint.sh /script/entrypoint.sh
+# Generate Diffie-Hellman Parameters (2048-bit)
+RUN openssl dhparam -out /etc/nginx/dhparam.pem 2048
 RUN chmod a+x /script/entrypoint.sh
 WORKDIR /script
 ENV DATA_UPLOAD_MAX_MEMORY_SIZE=12582912

--- a/conf/openimis.conf
+++ b/conf/openimis.conf
@@ -12,6 +12,17 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/${NEW_OPENIMIS_HOST}/privkey.pem;
     root /usr/share/nginx/html;
 
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256";
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
+    # Include the generated DH parameters
+    ssl_dhparam /etc/nginx/dhparam.pem;
+
     location /.well-known {
             root /var/www/html;
     }


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OS-102

DH params generation will be added to the Dockerfile. And will be used as a part of nginx config. 

I run my local openIMIS through dockerized build. Here there is a proof that it should work (local frontend container):
![Screenshot from 2025-03-14 13-18-00](https://github.com/user-attachments/assets/da6ae495-770f-49cd-992d-ae31df5b8778)
and the file is found in the expected path (local frontend container):
![Screenshot from 2025-03-14 13-17-35](https://github.com/user-attachments/assets/b9f0ecf2-3d6a-4ad4-9045-21980b49370c)

Related PR: 
https://github.com/openimis/openimis-dist_dkr/pull/71

OpenIMIS web app works as expected (local docker build):
![Screenshot from 2025-03-14 13-28-30](https://github.com/user-attachments/assets/b4050b2e-f9d0-4946-beca-b72fe6a6fe36)
