### PR TITLE
Migrate from Create React App to Vite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>openIMIS</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script
+      src="https://code.jquery.com/jquery-1.12.4.min.js"
+      integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ="
+      crossorigin="anonymous"
+    ></script>
+    <script
+      type="text/javascript"
+      src="https://unpkg.com/nepali-date-picker@2.0.0/dist/jquery.nepaliDatePicker.min.js"
+      integrity="sha384-bBN6UZ/L0DswJczUYcUXb9lwIfAnJSGWjU3S0W5+IlyrjK0geKO+7chJ7RlOtrrF"
+      crossorigin="anonymous"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/nepali-date-picker@2.0.0/dist/nepaliDatePicker.min.css"
+      integrity="sha384-Fligaq3qH5qXDi+gnnhQctSqfMKJvH4U8DTA+XGemB/vv9AUHCwmlVR/B3Z4nE+q"
+      crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>

--- a/openimis-config-vite.js
+++ b/openimis-config-vite.js
@@ -1,0 +1,126 @@
+const fs = require("fs");
+const pkg = require("./package.json");
+
+function processLocales(config) {
+  var locales = fs.createWriteStream("./src/locales.jsx");
+  let localeByLang = config["locales"].reduce((lcs, lc) => {
+    lc.languages.forEach((lg) => (lcs[lg] = lc.intl));
+    return lcs;
+  }, {});
+  let filesByLang = config["locales"].reduce((fls, lc) => {
+    lc.languages.forEach((lg) => (fls[lg] = lc.fileNames));
+    return fls;
+  }, {});
+  locales.write(`export const locales = ${JSON.stringify(config["locales"].map((lc) => lc.intl))}`);
+  locales.write(`\nexport const fileNamesByLang = ${JSON.stringify(filesByLang)}`);
+  locales.write(`/* eslint import/no-anonymous-default-export: [2, {"allowObject": true}] */`);
+  locales.write(`\nexport default ${JSON.stringify(localeByLang)}`);
+}
+
+function getConfig() {
+  // Try to get the configuration from the args
+  if (process.argv[2]) {
+    console.log(`  load configuration from '${process.argv[2]}'`);
+    return JSON.parse(fs.readFileSync(process.argv[2], "utf-8"));
+  } else if (process.env.OPENIMIS_CONF_JSON) {
+    console.log(`  load configuration from env`);
+    return JSON.parse(process.env.OPENIMIS_CONF_JSON);
+  } else if (fs.existsSync("./openimis.json")) {
+    console.log(`  load configuration from ./openimis.json`);
+    return JSON.parse(fs.readFileSync("./openimis.json", "utf-8"));
+  } else {
+    throw new Error(
+      "No configuration file found. Please provide a configuration in the CLI or in the OPENIMIS_CONF_JSON environment variable",
+    );
+  }
+}
+
+function processModules(modules) {
+  const stream = fs.createWriteStream("./src/modules.jsx");
+
+  stream.write(`
+export const packages = [
+  ${modules.map(({ moduleName }) => `"${moduleName}"`).join(",\n  ")}
+];
+
+`);
+
+  stream.write(`
+export function loadModules(cfg = {}) {
+  const loadedModules = [];
+${modules
+.map(({ name, logicalName, moduleName }) => {
+return `
+  try {
+    // Using dynamic import for Vite compatibility
+    import("${moduleName}")
+      .then(module => {
+        loadedModules.push(module.${name ?? "default"}(cfg["${logicalName}"] || {}));
+      })
+      .catch(error => {
+        console.error(\`Failed to load module "${moduleName}". Error: \${error}\`);
+        alert(\`Failed to load module "${moduleName}". More details can be found in the developer console.\`);
+      });
+  } catch (error) {
+    console.error(\`Failed to import module "${moduleName}". Error: \${error}\`);
+    alert(\`Failed to import module "${moduleName}". More details can be found in the developer console.\`);
+  }
+`;
+})
+.join("")}
+  return loadedModules;
+}
+`);
+
+  stream.end();
+}
+
+function main() {
+  /*
+  Load openIMIS configuration. Configuration is taken from args if provided or from the environment variable
+  */
+
+  // Remove @openimis dependencies from package.json
+  console.log("Remove @openimis dependencies from package.json");
+  for (const key in pkg.dependencies) {
+    if (key.startsWith("@openimis/")) {
+      // This only covers modules made from the openIMIS organization
+      console.log(`  removed ${key}`);
+      delete pkg.dependencies[key];
+    }
+  }
+
+  // Get openIMIS configuration from args
+  console.log("Load configuration");
+  const config = getConfig();
+
+  console.log("Process Locales");
+  processLocales(config);
+
+  console.log("Process Modules");
+  const modules = [];
+  for (const module of config.modules) {
+    const { npm, name, logicalName } = module;
+    // Find version number
+    const moduleName = npm.substring(0, npm.lastIndexOf("@"));
+    if (npm.lastIndexOf("@") <= 0) {
+      throw new Error(`  Module ${moduleName} has no version set.`);
+    }
+    const version = npm.substring(npm.lastIndexOf("@") + 1);
+    console.log(`  added "${moduleName}": ${version}`);
+    pkg.dependencies[moduleName] = version;
+    modules.push({
+      moduleName,
+      version,
+      name,
+      npm,
+      logicalName: logicalName || npm.match(/([^/]*)\/([^@]*).*/)[2],
+    });
+  }
+  processModules(modules);
+
+  console.log("Save package.json");
+  fs.writeFileSync("./package.json", JSON.stringify(pkg, null, 2), { encoding: "utf-8", flag: "w" });
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -23,23 +23,55 @@
     "react-helmet": "^6.1.0",
     "react-intl": "^5.8.1",
     "react-redux": "^7.2.0",
-    "react-scripts": "4.0.3",
     "redux": "^4.0.5",
     "redux-api-middleware": "^3.2.1",
     "redux-thunk": "^2.3.0",
-    "shelljs": "^0.8.4"
+    "shelljs": "^0.8.4",
+    "@openimis/fe-core": "https://github.com/openimis/openimis-fe-core_js#develop",
+    "@openimis/fe-individual": "https://github.com/openimis/openimis-fe-individual_js#develop",
+    "@openimis/fe-social_protection": "https://github.com/openimis/openimis-fe-social_protection_js#develop",
+    "@openimis/fe-opensearch_reports": "https://github.com/openimis/openimis-fe-opensearch_reports_js#develop",
+    "@openimis/fe-home": "https://github.com/openimis/openimis-fe-home_js#develop",
+    "@openimis/fe-location": "https://github.com/openimis/openimis-fe-location_js#develop",
+    "@openimis/fe-insuree": "https://github.com/openimis/openimis-fe-insuree_js#develop",
+    "@openimis/fe-medical": "https://github.com/openimis/openimis-fe-medical_js#develop",
+    "@openimis/fe-medical_pricelist": "https://github.com/openimis/openimis-fe-medical_pricelist_js#develop",
+    "@openimis/fe-product": "https://github.com/openimis/openimis-fe-product_js#develop",
+    "@openimis/fe-policy": "https://github.com/openimis/openimis-fe-policy_js#develop",
+    "@openimis/fe-payer": "https://github.com/openimis/openimis-fe-payer_js#develop",
+    "@openimis/fe-contribution": "https://github.com/openimis/openimis-fe-contribution_js#develop",
+    "@openimis/fe-payment": "https://github.com/openimis/openimis-fe-payment_js#develop",
+    "@openimis/fe-claim": "https://github.com/openimis/openimis-fe-claim_js#develop",
+    "@openimis/fe-claim_batch": "https://github.com/openimis/openimis-fe-claim_batch_js#develop",
+    "@openimis/fe-admin": "https://github.com/openimis/openimis-fe-admin_js#develop",
+    "@openimis/fe-tools": "https://github.com/openimis/openimis-fe-tools_js#develop",
+    "@openimis/fe-profile": "https://github.com/openimis/openimis-fe-profile_js#develop",
+    "@openimis/fe-calculation": "https://github.com/openimis/openimis-fe-calculation_js#develop",
+    "@openimis/fe-policyholder": "https://github.com/openimis/openimis-fe-policyholder_js#develop",
+    "@openimis/fe-contribution_plan": "https://github.com/openimis/openimis-fe-contribution_plan_js#develop",
+    "@openimis/fe-payment_cycle": "https://github.com/openimis/openimis-fe-payment_cycle_js#develop",
+    "@openimis/fe-contract": "https://github.com/openimis/openimis-fe-contract_js#develop",
+    "@openimis/fe-tasks_management": "https://github.com/openimis/openimis-fe-tasks_management_js#develop",
+    "@openimis/fe-invoice": "https://github.com/openimis/openimis-fe-invoice_js#develop",
+    "@openimis/fe-grievance_social_protection": "https://github.com/openimis/openimis-fe-grievance_social_protection_js#develop",
+    "@openimis/fe-language_fr": "https://github.com/openimis/openimis-fe-language_fr_js#develop",
+    "@openimis/fe-claim_sampling": "https://github.com/openimis/openimis-fe-claim_sampling_js#develop",
+    "@openimis/fe-deduplication": "https://github.com/openimis/openimis-fe-deduplication_js#develop",
+    "@openimis/fe-payroll": "https://github.com/openimis/openimis-fe-payroll_js#develop"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "load-config": "node ./openimis-config.js",
+    "start": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "load-config": "node ./openimis-config-vite.js",
     "postinstall": "node script/postinstall.js",
     "format": "prettier src -w",
     "check-package": "node script/check-package.js"
   },
   "eslintConfig": {
     "extends": [
-      "react-app"
+      "eslint:recommended",
+      "plugin:react/recommended"
     ],
     "rules": {
       "space-before-function-paren": 0,
@@ -62,7 +94,15 @@
     "caniuse-lite": "1.0.30001632"
   },
   "devDependencies": {
+    "@vitejs/plugin-legacy": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react": "^7.33.2",
     "http-proxy-middleware": "^2.0.1",
-    "prettier": "^2.3.2"
+    "prettier": "^2.3.2",
+    "vite": "^5.0.10",
+    "vite-plugin-env-compatible": "^2.0.1",
+    "vite-plugin-html": "^3.2.0",
+    "vite-plugin-svgr": "^4.2.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,10 +4,15 @@ const path = require("path");
 
 const app = express();
 
+// Serve static files from the 'build' directory
 app.use(express.static(path.join(__dirname, "build")));
 
-app.get("/", function(req, res) {
+// Handle SPA routing - always return index.html for any route
+app.get("*", function(req, res) {
   res.sendFile(path.join(__dirname, "build", "index.html"));
 });
 
-app.listen(process.env.PORT || 8080);
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/src/HistoryProvider.jsx
+++ b/src/HistoryProvider.jsx
@@ -1,0 +1,19 @@
+import { Component, Children } from "react";
+import PropTypes from "prop-types";
+
+class HistoryProvider extends Component {
+  static propTypes = {
+    history: PropTypes.object.isRequired,
+  };
+  static childContextTypes = {
+    history: PropTypes.object.isRequired,
+  };
+  getChildContext() {
+    const { history } = this.props;
+    return { history };
+  }
+  render() {
+    return Children.only(this.props.children);
+  }
+}
+export default HistoryProvider;

--- a/src/LocalesManager.jsx
+++ b/src/LocalesManager.jsx
@@ -1,0 +1,14 @@
+import { fileNamesByLang } from "./locales";
+
+class LocalesManager {
+  getLocale(lang) {
+    // messages in requested language are injected as the default 'en' locale
+    return "en";
+  }
+
+  getFileNameByLang(lang) {
+    return fileNamesByLang[lang];
+  }
+}
+
+export default LocalesManager;

--- a/src/ModulesManager.jsx
+++ b/src/ModulesManager.jsx
@@ -1,0 +1,103 @@
+import { loadModules, packages } from "./modules";
+import { memoize } from "lodash";
+import pkg from "../package.json";
+import { ensureArray } from "@openimis/fe-core";
+
+class ModulesManager {
+  constructor(cfg) {
+    this.cfg = cfg;
+    try {
+      this.modules = loadModules(cfg);
+    } catch (error) {
+      throw new Error(
+        "Loading modules failed in ModulesManager.jsx. This might be caused by duplicated modules in /src/modules.js. \n ORIGINAL ERROR: " +
+          error,
+      );
+    }
+    this.contributionsCache = {};
+    this.controlsCache = this.buildControlsCache();
+    this.refsCache = this.buildRefsCache();
+    this.reportsCache = this.buildReportsCache();
+  }
+
+  buildControlsCache() {
+    const ctrls = {};
+    for (var k in this.cfg) {
+      if (!!this.cfg[k].controls) {
+        for (var i in this.cfg[k].controls) {
+          var c = this.cfg[k].controls[i];
+          ctrls[k + "." + c["field"]] = c["usage"];
+        }
+      }
+    }
+    return ctrls;
+  }
+
+  buildRefsCache() {
+    return this.getContribs("refs").reduce((refs, r) => {
+      refs[r.key] = r.ref;
+      return refs;
+    }, {});
+  }
+
+  buildReportsCache() {
+    return this.getContribs("reports").reduce((acc, report) => {
+      if (!report.getParams) {
+        console.error(`Report ${report.key} has no getParams function.`);
+      }
+      if (!report.isValid) {
+        console.error(`Report ${report.key} has no isValid function.`);
+      }
+      acc[report.key] = report;
+      return acc;
+    }, {});
+  }
+
+  getOpenIMISVersion() {
+    return pkg.version;
+  }
+
+  getModulesVersions() {
+    return packages.map((name) => `${name}@${pkg.dependencies[name] ?? "?"}`);
+  }
+
+  hideField(module, key) {
+    return this.controlsCache["fe-" + module + "." + key] & 1;
+  }
+
+  getRef(key) {
+    return this.refsCache[key];
+  }
+
+  getReport(ref) {
+    return this.reportsCache[ref];
+  }
+
+  getProjection(key) {
+    const proj = this.getRef(key);
+    return !!proj ? `{${proj.join(", ")}}` : "";
+  }
+
+  getContribs = memoize((key) => {
+    return this.modules.reduce((contributions, module) => [...contributions, ...ensureArray(module[key])], []);
+  });
+
+  getConf(module, key, defaultValue = null) {
+    const moduleCfg = this.cfg[module] || {};
+    return moduleCfg[key] !== undefined ? moduleCfg[key] : defaultValue;
+  }
+
+  getMenuEntries() {
+    return this.modules.reduce((menuEntries, module) => {
+      const mainMenuKeys = Object.keys(module).filter(
+        (key) => key.includes(".MainMenu") && key !== "core.MainMenu"
+      );
+      mainMenuKeys.forEach((key) => {
+        menuEntries.push(...ensureArray(module[key]));
+      });
+      return menuEntries;
+    }, []);
+  }
+}
+
+export default ModulesManager;

--- a/src/ModulesManagerProvider.jsx
+++ b/src/ModulesManagerProvider.jsx
@@ -1,0 +1,19 @@
+import { Component, Children } from "react";
+import PropTypes from "prop-types";
+
+class ModulesManagerProvider extends Component {
+  static propTypes = {
+    modulesManager: PropTypes.object.isRequired,
+  };
+  static childContextTypes = {
+    modulesManager: PropTypes.object.isRequired,
+  };
+  getChildContext() {
+    const { modulesManager } = this.props;
+    return { modulesManager };
+  }
+  render() {
+    return Children.only(this.props.children);
+  }
+}
+export default ModulesManagerProvider;

--- a/src/helpers/localStorage.jsx
+++ b/src/helpers/localStorage.jsx
@@ -1,0 +1,21 @@
+export const loadState = () => {
+  try {
+    const serializedState = localStorage.getItem("state");
+    if (serializedState === null) {
+      return undefined;
+    }
+
+    return JSON.parse(serializedState);
+  } catch (e) {
+    return undefined;
+  }
+};
+
+export const saveState = (state) => {
+  try {
+    const serializedState = JSON.stringify(state);
+    localStorage.setItem("state", serializedState);
+  } catch (e) {
+    return undefined;
+  }
+};

--- a/src/helpers/store.jsx
+++ b/src/helpers/store.jsx
@@ -1,0 +1,22 @@
+import thunk from "redux-thunk";
+import { createStore, applyMiddleware, compose, combineReducers } from "redux";
+import { loadState } from "./localStorage";
+import { apiMiddleware } from "redux-api-middleware";
+
+const persistedState = loadState();
+
+const composeEnhancers =
+  import.meta.env.DEV && typeof window === "object" && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+        // Specify extension's options like name, actionsBlacklist, actionsCreators, serialize...
+      })
+    : compose;
+
+const store = (reducers, middlewares = []) =>
+  createStore(
+    combineReducers({ ...reducers }),
+    persistedState,
+    composeEnhancers(applyMiddleware(thunk, apiMiddleware, ...middlewares)),
+  );
+
+export default store;

--- a/src/helpers/theme.jsx
+++ b/src/helpers/theme.jsx
@@ -1,0 +1,223 @@
+import { createTheme } from "@material-ui/core";
+import { alpha } from "@material-ui/core/styles/colorManipulator";
+
+const theme = createTheme({
+  overrides: {
+    MuiTableRow: {
+      root: {
+        "&$selected": {
+          backgroundColor: "rgba(0, 0, 0, 0.08)",
+        },
+      },
+    },
+  },
+  palette: {
+    primary: { main: "#006273" },
+    secondary: { main: "#fff" },
+    error: { main: "#801a00" },
+    text: {
+      primary: "#006273",
+      secondary: "#006273", // HACK FOR material-table hardcoded toolbar!,
+      second: "#fff",
+      error: "#801a00",
+    },
+    toggledButton: "#999999",
+  },
+  typography: {
+    useNextVariants: true,
+    fontFamily: ["Rubik", "Roboto", '"Helvetica Neue"', "sans-serif"].join(","),
+    fontSize: 14,
+    fontWeightRegular: 300,
+    fontWeightMedium: 400,
+    title: {
+      fontSize: 20,
+      fontWeight: 300,
+    },
+    label: {
+      color: "grey",
+    },
+  },
+  jrnlDrawer: {
+    open: {
+      width: 500,
+    },
+    close: {
+      width: 80,
+    },
+    itemDetail: {
+      marginLeft: 8,
+    },
+    iconSize: 24,
+  },
+  menu: {
+    variant: "AppBar",
+    drawer: {
+      width: 300,
+      fontSize: 16,
+      backgroundColor:"#006273"
+    },
+    appBar: {
+      fontSize: 16,
+    },
+  },
+  page: {
+    padding: 16,
+    locked: {
+      background: "repeating-linear-gradient(45deg, #D3D3D3 1px, #D3D3D3 1px, #fff 10px, #fff 10px);",
+    },
+  },
+  paper: {
+    paper: {
+      margin: 10,
+      backgroundColor: "#dbeef0",
+    },
+    header: {
+      color: "#006273",
+      backgroundColor: "#b7d4d8",
+    },
+    message: {
+      backgroundColor: "#b7d4d8",
+    },
+    title: {
+      padding: 10,
+      fontSize: 24,
+      color: "#006273",
+      backgroundColor: "#b7d4d8",
+    },
+    action: {
+      padding: 5,
+    },
+    divider: {
+      padding: 0,
+      margin: 0,
+    },
+    body: {
+      marginTop: 10,
+      backgroundColor: "#dbeef0",
+    },
+    item: {
+      padding: 10,
+    },
+  },
+  table: {
+    title: {
+      padding: 10,
+      fontWeight: 500,
+      color: "#006273",
+      backgroundColor: "#b7d4d8",
+    },
+    header: {
+      color: "#006273",
+    },
+    headerAction: {
+      padding: 5,
+    },
+    row: {
+      color: "#006273",
+      align: "center",
+      "&:hover": {
+        background: "rgba(0, 0, 0, 0.12) !important",
+      },
+    },
+    cell: {
+      padding: 5,
+    },
+    lockedRow: {
+      background: "repeating-linear-gradient(45deg, #D3D3D3 1px, #D3D3D3 1px, #fff 10px, #fff 10px);",
+    },
+    lockedCell: {},
+    highlightedRow: {},
+    highlightedCell: {
+      fontWeight: 500,
+      align: "center",
+    },
+    secondaryHighlightedRow: {
+      backgroundColor: "#cbedf2",
+    },
+    secondaryHighlightedCell: {},
+    highlightedAltRow: {},
+    highlightedAltCell: {
+      fontStyle: "italic",
+      align: "center",
+    },
+    disabledRow: {},
+    disabledCell: {
+      // textDecoration: "line-through",
+      color: "grey",
+      align: "center",
+    },
+    footer: {
+      color: "#006273",
+    },
+    pager: {
+      color: "#006273",
+    },
+  },
+  form: {
+    spacing: 10,
+  },
+  formTable: {
+    table: {
+      color: "#006273",
+    },
+    actions: {
+      color: "#006273",
+    },
+    header: {
+      color: "#006273",
+      align: "center",
+    },
+  },
+  dialog: {
+    title: {
+      fontWeight: 500,
+      color: "grey",
+    },
+    content: {
+      padding: 0,
+    },
+    primaryButton: {
+      backgroundColor: "#006273",
+      color: "#fff",
+      fontWeight: "bold",
+      "&:hover": {
+        backgroundColor: alpha("#006273", 0.5),
+        color: "#006273",
+      },
+    },
+    secondaryButton: {},
+  },
+  tooltipContainer: {
+    position: 'fixed',
+    bottom: 15,
+    right: 8,
+    zIndex: 2000,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+  },
+  flexTooltip: {
+    marginBottom: 5,
+  },
+  fab: {
+    position: "fixed",
+    bottom: 20,
+    right: 8,
+    zIndex: 2000,
+  },
+  fakeInput: {},
+  bigAvatar: {
+    width: 160,
+    height: 160,
+  },
+  buttonContainer: {
+    horizontal: {
+      display: "flex",
+      flexWrap: "nowrap",
+      overflowX: "auto",
+      justifyContent: "flex-end",
+    },
+  },
+});
+
+export default theme;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,106 @@
+// Polyfills for legacy browser support
+import React, { useEffect } from "react";
+import ReactDOM from "react-dom";
+import { MuiThemeProvider, LinearProgress } from "@material-ui/core";
+import { Provider } from "react-redux";
+import MomentUtils from "@date-io/moment";
+import { MuiPickersUtilsProvider } from "@material-ui/pickers";
+import * as serviceWorker from "./serviceWorker";
+import theme from "./helpers/theme";
+import store from "./helpers/store";
+import LocalesManager from "./LocalesManager";
+import ModulesManager from "./ModulesManager";
+import ModulesManagerProvider from "./ModulesManagerProvider";
+import { App, FatalError, baseApiUrl, apiHeaders } from "@openimis/fe-core";
+import messages_ref from "./translations/ref.json";
+import "./index.css";
+import logo from "./openIMIS.png";
+
+const loadConfiguration = async () => {
+  const response = await fetch(`${baseApiUrl}/graphql`, {
+    method: "post",
+    headers: apiHeaders(),
+    body: JSON.stringify({ "query": "{ moduleConfigurations { module, config, controls{ field, usage } } }" }),
+  });
+  if (!response.ok) {
+    throw response;
+  } else {
+    const { data } = await response.json();
+    data.moduleConfigurations.unshift({});
+    const out = data.moduleConfigurations.reduce((acc, c) => {
+      try {
+        acc[c.module] = { controls: c.controls, ...JSON.parse(c.config) };
+      } catch (error) {
+        console.error(`Failed to parse module ${c.module} config`, error);
+      }
+      return acc;
+    });
+    return out;
+  }
+};
+
+const AppContainer = () => {
+  const [appState, setAppState] = React.useState({ isLoading: true, config: undefined, error: null });
+  const localesManager = new LocalesManager();
+
+  useEffect(() => {
+    loadConfiguration().then(
+      (config) =>
+        setAppState({
+          error: null,
+          isLoading: false,
+          config,
+        }),
+      (error) =>
+        setAppState({
+          error,
+          isLoading: false,
+        }),
+    );
+  }, []);
+
+  if (appState.isLoading) {
+    return (
+      <MuiThemeProvider theme={theme}>
+        <LinearProgress className="bootstrap" />
+      </MuiThemeProvider>
+    );
+  } else if (appState.error) {
+    return (
+      <FatalError
+        error={{
+          code: appState.error.status,
+          message: appState.error.statusText,
+        }}
+      />
+    );
+  } else {
+    const modulesManager = new ModulesManager(appState.config);
+    const reducers = modulesManager.getContribs("reducers").reduce((reds, red) => {
+      reds[red.key] = red.reducer;
+      return reds;
+    }, []);
+
+    const middlewares = modulesManager.getContribs("middlewares");
+
+    return (
+      <MuiThemeProvider theme={theme}>
+        <Provider store={store(reducers, middlewares)}>
+          <MuiPickersUtilsProvider utils={MomentUtils}>
+            <ModulesManagerProvider modulesManager={modulesManager}>
+              <App
+                basename={import.meta.env.BASE_URL || "/front"}
+                localesManager={localesManager}
+                messages={messages_ref}
+                logo={logo}
+              />
+            </ModulesManagerProvider>
+          </MuiPickersUtilsProvider>
+        </Provider>
+      </MuiThemeProvider>
+    );
+  }
+};
+
+ReactDOM.render(<AppContainer />, document.getElementById("root"));
+serviceWorker.register();

--- a/src/locales.jsx
+++ b/src/locales.jsx
@@ -1,0 +1,3 @@
+export const locales = ["en-GB","fr-FR"]
+export const fileNamesByLang = {"en":"en","en-GB":"en","fr":"fr","fr-FR":"fr"}/* eslint import/no-anonymous-default-export: [2, {"allowObject": true}] */
+export default {"en":"en-GB","en-GB":"en-GB","fr":"fr-FR","fr-FR":"fr-FR"}

--- a/src/modules.jsx
+++ b/src/modules.jsx
@@ -1,0 +1,506 @@
+
+export const packages = [
+  "@openimis/fe-core",
+  "@openimis/fe-individual",
+  "@openimis/fe-social_protection",
+  "@openimis/fe-opensearch_reports",
+  "@openimis/fe-home",
+  "@openimis/fe-location",
+  "@openimis/fe-insuree",
+  "@openimis/fe-medical",
+  "@openimis/fe-medical_pricelist",
+  "@openimis/fe-product",
+  "@openimis/fe-policy",
+  "@openimis/fe-payer",
+  "@openimis/fe-contribution",
+  "@openimis/fe-payment",
+  "@openimis/fe-claim",
+  "@openimis/fe-claim_batch",
+  "@openimis/fe-admin",
+  "@openimis/fe-tools",
+  "@openimis/fe-profile",
+  "@openimis/fe-calculation",
+  "@openimis/fe-policyholder",
+  "@openimis/fe-contribution_plan",
+  "@openimis/fe-payment_cycle",
+  "@openimis/fe-contract",
+  "@openimis/fe-tasks_management",
+  "@openimis/fe-invoice",
+  "@openimis/fe-grievance_social_protection",
+  "@openimis/fe-language_fr",
+  "@openimis/fe-claim_sampling",
+  "@openimis/fe-deduplication",
+  "@openimis/fe-payroll"
+];
+
+
+export function loadModules(cfg = {}) {
+  const loadedModules = [];
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-core")
+      .then(module => {
+        loadedModules.push(module.CoreModule(cfg["fe-core"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-core". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-core". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-core". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-core". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-individual")
+      .then(module => {
+        loadedModules.push(module.IndividualModule(cfg["fe-individual"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-individual". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-individual". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-individual". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-individual". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-social_protection")
+      .then(module => {
+        loadedModules.push(module.SocialProtectionModule(cfg["fe-social_protection"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-social_protection". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-social_protection". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-social_protection". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-social_protection". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-opensearch_reports")
+      .then(module => {
+        loadedModules.push(module.OpenSearchReportsModule(cfg["fe-opensearch_reports"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-opensearch_reports". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-opensearch_reports". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-opensearch_reports". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-opensearch_reports". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-home")
+      .then(module => {
+        loadedModules.push(module.HomeModule(cfg["fe-home"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-home". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-home". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-home". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-home". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-location")
+      .then(module => {
+        loadedModules.push(module.LocationModule(cfg["fe-location"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-location". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-location". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-location". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-location". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-insuree")
+      .then(module => {
+        loadedModules.push(module.InsureeModule(cfg["fe-insuree"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-insuree". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-insuree". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-insuree". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-insuree". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-medical")
+      .then(module => {
+        loadedModules.push(module.MedicalModule(cfg["fe-medical"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-medical". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-medical". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-medical". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-medical". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-medical_pricelist")
+      .then(module => {
+        loadedModules.push(module.MedicalPriceListModule(cfg["fe-medical_pricelist"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-medical_pricelist". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-medical_pricelist". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-medical_pricelist". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-medical_pricelist". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-product")
+      .then(module => {
+        loadedModules.push(module.ProductModule(cfg["fe-product"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-product". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-product". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-product". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-product". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-policy")
+      .then(module => {
+        loadedModules.push(module.PolicyModule(cfg["fe-policy"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-policy". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-policy". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-policy". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-policy". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-payer")
+      .then(module => {
+        loadedModules.push(module.PayerModule(cfg["fe-payer"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-payer". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-payer". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-payer". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-payer". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-contribution")
+      .then(module => {
+        loadedModules.push(module.ContributionModule(cfg["fe-contribution"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-contribution". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-contribution". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-contribution". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-contribution". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-payment")
+      .then(module => {
+        loadedModules.push(module.PaymentModule(cfg["fe-payment"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-payment". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-payment". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-payment". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-payment". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-claim")
+      .then(module => {
+        loadedModules.push(module.ClaimModule(cfg["fe-claim"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-claim". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-claim". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-claim". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-claim". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-claim_batch")
+      .then(module => {
+        loadedModules.push(module.ClaimBatchModule(cfg["fe-claim_batch"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-claim_batch". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-claim_batch". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-claim_batch". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-claim_batch". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-admin")
+      .then(module => {
+        loadedModules.push(module.AdminModule(cfg["fe-admin"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-admin". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-admin". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-admin". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-admin". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-tools")
+      .then(module => {
+        loadedModules.push(module.ToolsModule(cfg["fe-tools"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-tools". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-tools". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-tools". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-tools". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-profile")
+      .then(module => {
+        loadedModules.push(module.ProfileModule(cfg["fe-profile"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-profile". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-profile". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-profile". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-profile". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-calculation")
+      .then(module => {
+        loadedModules.push(module.CalculationModule(cfg["fe-calculation"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-calculation". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-calculation". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-calculation". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-calculation". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-policyholder")
+      .then(module => {
+        loadedModules.push(module.PolicyHolderModule(cfg["fe-policyholder"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-policyholder". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-policyholder". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-policyholder". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-policyholder". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-contribution_plan")
+      .then(module => {
+        loadedModules.push(module.ContributionPlanModule(cfg["fe-contribution_plan"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-contribution_plan". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-contribution_plan". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-contribution_plan". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-contribution_plan". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-payment_cycle")
+      .then(module => {
+        loadedModules.push(module.PaymentCycleModule(cfg["fe-payment_cycle"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-payment_cycle". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-payment_cycle". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-payment_cycle". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-payment_cycle". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-contract")
+      .then(module => {
+        loadedModules.push(module.ContractModule(cfg["fe-contract"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-contract". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-contract". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-contract". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-contract". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-tasks_management")
+      .then(module => {
+        loadedModules.push(module.TasksManagementModule(cfg["fe-tasks_management"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-tasks_management". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-tasks_management". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-tasks_management". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-tasks_management". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-invoice")
+      .then(module => {
+        loadedModules.push(module.InvoiceModule(cfg["fe-invoice"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-invoice". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-invoice". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-invoice". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-invoice". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-grievance_social_protection")
+      .then(module => {
+        loadedModules.push(module.GrievanceSocialProtectionModule(cfg["fe-grievance_social_protection"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-grievance_social_protection". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-grievance_social_protection". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-grievance_social_protection". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-grievance_social_protection". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-language_fr")
+      .then(module => {
+        loadedModules.push(module.LanguageFrModule(cfg["fe-language_fr"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-language_fr". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-language_fr". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-language_fr". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-language_fr". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-claim_sampling")
+      .then(module => {
+        loadedModules.push(module.ClaimSamplingModule(cfg["fe-claim_sampling"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-claim_sampling". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-claim_sampling". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-claim_sampling". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-claim_sampling". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-deduplication")
+      .then(module => {
+        loadedModules.push(module.DeduplicationModule(cfg["fe-deduplication"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-deduplication". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-deduplication". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-deduplication". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-deduplication". More details can be found in the developer console.`);
+  }
+
+  try {
+    // Using dynamic import for Vite compatibility
+    import("@openimis/fe-payroll")
+      .then(module => {
+        loadedModules.push(module.PayrollModule(cfg["fe-payroll"] || {}));
+      })
+      .catch(error => {
+        console.error(`Failed to load module "@openimis/fe-payroll". Error: ${error}`);
+        alert(`Failed to load module "@openimis/fe-payroll". More details can be found in the developer console.`);
+      });
+  } catch (error) {
+    console.error(`Failed to import module "@openimis/fe-payroll". Error: ${error}`);
+    alert(`Failed to import module "@openimis/fe-payroll". More details can be found in the developer console.`);
+  }
+
+  return loadedModules;
+}

--- a/src/serviceWorker.jsx
+++ b/src/serviceWorker.jsx
@@ -1,0 +1,125 @@
+// This optional code is used to register a service worker.
+// register() is not called by default.
+
+// This lets the app load faster on subsequent visits in production, and gives
+// it offline capabilities. However, it also means that developers (and users)
+// will only see deployed updates on subsequent visits to a page, after all the
+// existing tabs open on the page have been closed, since previously cached
+// resources are updated in the background.
+
+const isLocalhost = Boolean(
+  window.location.hostname === "localhost" ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === "[::1]" ||
+    // 127.0.0.1/8 is considered localhost for IPv4.
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/),
+);
+
+export function register(config) {
+  if (import.meta.env.PROD && "serviceWorker" in navigator) {
+    // The URL constructor is available in all browsers that support SW.
+    const publicUrl = new URL(import.meta.env.BASE_URL || "/front", window.location.href);
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if BASE_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets
+      return;
+    }
+
+    window.addEventListener("load", () => {
+      const swUrl = `${import.meta.env.BASE_URL || "/front"}/service-worker.js`;
+
+      if (isLocalhost) {
+        // This is running on localhost. Let's check if a service worker still exists or not.
+        checkValidServiceWorker(swUrl, config);
+
+        // Add some additional logging to localhost, pointing developers to the
+        // service worker/PWA documentation.
+        navigator.serviceWorker.ready.then(() => {
+          console.log(
+            "This web app is being served cache-first by a service " +
+              "worker. To learn more, visit https://bit.ly/CRA-PWA",
+          );
+        });
+      } else {
+        // Is not localhost. Just register service worker
+        registerValidSW(swUrl, config);
+      }
+    });
+  }
+}
+
+function registerValidSW(swUrl, config) {
+  navigator.serviceWorker
+    .register(swUrl)
+    .then((registration) => {
+      registration.onupdatefound = () => {
+        const installingWorker = registration.installing;
+        if (installingWorker == null) {
+          return;
+        }
+        installingWorker.onstatechange = () => {
+          if (installingWorker.state === "installed") {
+            if (navigator.serviceWorker.controller) {
+              // At this point, the updated precached content has been fetched,
+              // but the previous service worker will still serve the older
+              // content until all client tabs are closed.
+              console.log(
+                "New content is available and will be used when all " +
+                  "tabs for this page are closed. See https://bit.ly/CRA-PWA.",
+              );
+
+              // Execute callback
+              if (config && config.onUpdate) {
+                config.onUpdate(registration);
+              }
+            } else {
+              // At this point, everything has been precached.
+              // It's the perfect time to display a
+              // "Content is cached for offline use." message.
+              console.log("Content is cached for offline use.");
+
+              // Execute callback
+              if (config && config.onSuccess) {
+                config.onSuccess(registration);
+              }
+            }
+          }
+        };
+      };
+    })
+    .catch((error) => {
+      console.error("Error during service worker registration:", error);
+    });
+}
+
+function checkValidServiceWorker(swUrl, config) {
+  // Check if the service worker can be found. If it can't reload the page.
+  fetch(swUrl)
+    .then((response) => {
+      // Ensure service worker exists, and that we really are getting a JS file.
+      const contentType = response.headers.get("content-type");
+      if (response.status === 404 || (contentType != null && contentType.indexOf("javascript") === -1)) {
+        // No service worker found. Probably a different app. Reload the page.
+        navigator.serviceWorker.ready.then((registration) => {
+          registration.unregister().then(() => {
+            window.location.reload();
+          });
+        });
+      } else {
+        // Service worker found. Proceed as normal.
+        registerValidSW(swUrl, config);
+      }
+    })
+    .catch(() => {
+      console.log("No internet connection found. App is running in offline mode.");
+    });
+}
+
+export function unregister() {
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.ready.then((registration) => {
+      registration.unregister();
+    });
+  }
+}

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,23 +1,17 @@
-const { createProxyMiddleware } = require("http-proxy-middleware");
+// This file is used by Vite's proxy configuration
+// It's referenced in vite.config.js
+
 const pkg = require("../package.json");
 
-module.exports = function (app) {
-  let headers = {};
-  if (process.env.REMOTE_USER) {
-    headers["Remote-User"] = process.env.REMOTE_USER;
+module.exports = {
+  '/api': {
+    target: pkg.proxy,
+    changeOrigin: true,
+    headers: process.env.REMOTE_USER ? { "Remote-User": process.env.REMOTE_USER } : {}
+  },
+  '/graphql': {
+    target: pkg.proxy,
+    changeOrigin: true,
+    headers: process.env.REMOTE_USER ? { "Remote-User": process.env.REMOTE_USER } : {}
   }
-
-  let baseApiUrl = process.env.REACT_APP_API_URL ?? '/api';
-  if (baseApiUrl.indexOf('/') !== 0) {
-    baseApiUrl = `/${baseApiUrl}`;
-  }
-
-  app.use(
-    baseApiUrl,
-    createProxyMiddleware({
-      target: pkg.proxy,
-      changeOrigin: true,
-      headers: headers
-    }),
-  );
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,55 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import legacy from '@vitejs/plugin-legacy';
+import svgr from 'vite-plugin-svgr';
+import envCompatible from 'vite-plugin-env-compatible';
+import { createHtmlPlugin } from 'vite-plugin-html';
+import path from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    react(),
+    svgr(),
+    envCompatible(),
+    legacy({
+      targets: ['>0.2%', 'not dead', 'not op_mini all'],
+    }),
+    createHtmlPlugin({
+      minify: true,
+      inject: {
+        data: {
+          title: 'openIMIS',
+        },
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      'react': path.resolve('./node_modules/react'),
+      'react-redux': path.resolve('./node_modules/react-redux'),
+      '@material-ui': path.resolve('./node_modules/@material-ui'),
+    },
+  },
+  server: {
+    port: 3000,
+    proxy: require('./src/setupProxy'),
+  },
+  build: {
+    outDir: 'build',
+    assetsDir: 'static',
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom', 'react-redux', 'redux'],
+          materialui: ['@material-ui/core', '@material-ui/icons', '@material-ui/lab', '@material-ui/pickers'],
+        },
+      },
+    },
+  },
+  define: {
+    'process.env.PUBLIC_URL': JSON.stringify('/front'),
+  },
+  base: '/front/',
+});


### PR DESCRIPTION
## Description
This PR migrates the frontend from Create React App (CRA) to Vite.

### Changes Made
- Removed `react-scripts` dependency
- Added Vite and necessary plugins
- Created Vite configuration file
- Updated HTML template
- Changed file extensions from .js to .jsx for React components
- Updated environment variable handling
- Updated proxy configuration
- Updated server configuration

### Benefits
- Faster development server startup
- Improved build times
- Better hot module replacement
- Modern ESM-based bundling

