### PR TITLE
refactor: Enhance Configuration Lookup in ModulesManager (getConf)

### DIFF
--- a/src/ModulesManager.js
+++ b/src/ModulesManager.js
@@ -11,7 +11,7 @@ class ModulesManager {
     } catch (error) {
       throw new Error(
         "Loading modules failed in ModulesManager.js. This might be caused by duplicated modules in /src/modules.js. \n ORIGINAL ERROR: " +
-          error,
+        error,
       );
     }
     this.contributionsCache = {};
@@ -84,7 +84,20 @@ class ModulesManager {
 
   getConf(module, key, defaultValue = null) {
     const moduleCfg = this.cfg[module] || {};
-    return moduleCfg[key] !== undefined ? moduleCfg[key] : defaultValue;
+    let value = moduleCfg[key] !== undefined ? moduleCfg[key] : null;
+
+    if (value == null) {
+      this.modules.forEach(m => {
+        if (m[key] !== undefined) {
+          value = m[key];
+        }
+      })
+    }
+
+    if (value == null) {
+      value = defaultValue;
+    }
+    return value;
   }
 
   getMenuEntries() {


### PR DESCRIPTION
### Problem & Context
The previous getConf method in ModulesManager.js only allowed configuration values to be retrieved directly from the specific module's configuration (this.cfg[module]). This limited the flexibility for modules to provide their own default or override configurations that might not be explicitly set at the top level.

This approach could lead to:
- Redundant configuration definitions if a default value needed to be applied across multiple modules but wasn't explicitly set for each.
- Less dynamic configuration where modules couldn't "advertise" their own default settings.

### Solution
This PR refactors the getConf method to introduce a more robust and flexible configuration lookup mechanism.

The updated getConf method now follows a clear precedence for retrieving configuration values:

- Module-Specific Configuration First: It first attempts to retrieve the key from the moduleCfg (i.e., this.cfg[module]). This ensures that explicitly defined module-level configurations take highest priority.
- Module-Defined Fallback: If the key is not found in the moduleCfg (or its value is null), the method now iterates through all registered modules (this.modules). It will assign the value from the first module that defines the key (or more accurately, the last module encountered in the iteration if multiple modules define the same key).
- Default Value as Last Resort: If the key is still not found after checking both the module-specific configuration and iterating through all registered modules, it finally falls back to the provided defaultValue.
