### PR TITLE
Fix: Prevent Webpack source map warnings from failing build output

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -24,6 +24,17 @@ module.exports = {
         })
       );
 
+      webpackConfig.ignoreWarnings = [
+        {
+          module: /@formatjs\/fast-memoize/,
+          message: /Failed to parse source map/,
+        },
+        {
+          module: /react-double-scrollbar/,
+          message: /Failed to parse source map/,
+        },
+      ];
+
       return webpackConfig;
     },
   },


### PR DESCRIPTION
# Description

This PR updates the Webpack configuration to prevent build failures caused by source map parsing errors in specific dependencies: 
* @formatjs/fast-memoize
* react-double-scrollbar 

## Changes

* [x] suppress source map warnings for `@formatjs/fast-memoize` and `react-double-scrollbar` in Webpack config

## Demo

## How to Test

1. Pull the branch with this PR.
2. follow the Devtools (https://github.com/openimis/openimis-dev-tools) installation steps (for the development environment) and ensure all repositories are under develop