### PR TITLE
fix: correct config script invocation, typo, and import path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN npm config set prefix /home/node/.npm-global
 RUN npm install -g npm@latest
 RUN npm install -g shelljs yargs
 RUN npm install --legacy-peer-deps --include=dev
-RUN npm run load-config -- -c ./openimis.json
+RUN node ./openimis-config-vite.js -c ./openimis.json
 RUN npm install --legacy-peer-deps --include=dev
 RUN npx vite build --mode $MODE
 

--- a/openimis-config-vite.js
+++ b/openimis-config-vite.js
@@ -122,7 +122,7 @@ function processModules(modules, modulesInstallPath) {
       dynamicBlocks.push(`
   // 🔄 Dynamically importing ${name}
   try {
-    const module = await import("${localPath}");
+    const module = await import("${packageName}");
     loadedModules.push(
       module.${name ?? "default"}(cfg["${logicalName}"] || {})
     );
@@ -172,8 +172,8 @@ function processViteConfig(modules) {
   const placeholder = '//<<DYNAMIC_ALIAS_PLACEHOLDER>>';
   const placeholderIndex = viteConfigContent.indexOf(placeholder);
   if (placeholderIndex === -1) {
-    console.error("Placeholder not found in vite.config.js.");
-    process.exit(1);
+    console.warn("Placeholder //<<DYNAMIC_ALIAS_PLACEHOLDER>> not found in vite.config.js. Skipping dynamic alias injection. Module resolution may fail for git/npm module specs if aliases are required.");
+    return;
   }
 
   // Step 3: Inject new aliases on the line(s) after the placeholder
@@ -195,7 +195,7 @@ function processViteConfig(modules) {
   // Write back the updated vite config
   try {
     fs.writeFileSync("./vite.config.js", viteConfigContent, "utf-8");
-    console.log("Updated vite.config.js with dynamic aliases");
+    console.log("Updated vite.config.js with dynamic aliases for configured modules");
   } catch (error) {
     console.error(`Error writing vite.config.js: ${error.message}`);
   }
@@ -345,7 +345,7 @@ if (require.main === module) {
       .help()
       .alias('help', 'h')
       .argv;
-    if (process.env.OPENIMIS_CONF !== 'undefiend' && argv.config === null){
+    if (process.env.OPENIMIS_CONF !== 'undefined' && argv.config === null){
       argv.config = process.env.OPENIMIS_CONF
     }
     console.log(`Config path: ${argv.config}, Modules path: ${argv.path}`);

--- a/src/modules.jsx
+++ b/src/modules.jsx
@@ -39,14 +39,14 @@ export const packages = [
 
 export async function loadModules(cfg = {}) {
   const loadedModules = [];
-
+  
   // 🔄 Statically imported CoreModule
   try {
     loadedModules.push(
       CoreModule(cfg["fe-core"] || {})
     );
   } catch (error) {
-    console.error(`❌ Failed to import module "CoreModule". Error: ${error}`);
+    console.error(`❌ Failed to initialize module "CoreModule". Error: ${error}`);
     alert(`Failed to load module "CoreModule". See console for details.`);
   }
 
@@ -368,7 +368,6 @@ export async function loadModules(cfg = {}) {
     console.error(`❌ Failed to import module "PayrollModule". Error: ${error}`);
     alert(`Failed to load module "PayrollModule". See console for details.`);
   }
-
 
   // 🔄 Dynamically importing FormBuilderModule
   try {


### PR DESCRIPTION
- Replace `npm run load-config` with direct `node` invocation in Dockerfile to avoid potential script resolution issues
- Fix typo in env var check: 'undefiend' → 'undefined', which caused the OPENIMIS_CONF env variable to never be used as fallback config
- Use `packageName` instead of `localPath` for dynamic module imports to ensure proper Vite/npm package resolution
- Downgrade missing vite.config.js placeholder from fatal error to warning to allow graceful degradation when aliases are not required
- Improve log/error messages for clarity and minor whitespace cleanup

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
