### PR TITLE
feat: support configurable input variant from fe-core configuration - OP-3079

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,25 @@ To override the default theme colors, provide a `theme` object under the `fe-cor
 
 **Note:** If `theme` is not provided, the default openIMIS theme will be used instead.
 
+#### Input Variant Configuration (`Input.variant`)
+
+You can globally change the style of all form inputs (TextField, Select, DatePicker, Autocomplete, etc.) by setting the variant under the `fe-core` configuration:
+
+```json
+{
+  "Input": {
+    "variant": "standard"
+  }
+}
+```
+
+Supported values:
+- `"standard"` — underlined style (default)
+- `"outlined"` — bordered box style
+- `"filled"` — filled box style
+
+The configuration is read at application start and falls back to `"standard"` when not provided. It affects both the MUI theme defaults and the shared input components from CoreModule.
+
 ---
 
 #### 🖼️ Logo Configuration (`logo`)

--- a/src/helpers/theme.jsx
+++ b/src/helpers/theme.jsx
@@ -31,9 +31,9 @@ const createAppTheme = (colorOverrides = {}, feCoreConfig = {}) => {
     lockedBackgroundPattern,
   } = { ...defaultColors, ...colorOverrides };
 
-  const inputVariant = feCoreConfig?.Input?.variant
-    || feCoreConfig?.inputVariant
-    || "standard";
+  const configuredVariant = feCoreConfig?.Input?.variant ?? feCoreConfig?.inputVariant;
+  const normalizedVariant = typeof configuredVariant === "string" ? configuredVariant.toLowerCase() : undefined;
+  const inputVariant = ["standard", "outlined", "filled"].includes(normalizedVariant) ? normalizedVariant : "standard";
 
   const themeOptions = {
     breakpoints: {

--- a/src/helpers/theme.jsx
+++ b/src/helpers/theme.jsx
@@ -16,7 +16,7 @@ const defaultColors = {
     "repeating-linear-gradient(45deg, #D3D3D3 1px, #D3D3D3 1px, #fff 10px, #fff 10px)",
 };
 
-const createAppTheme = (colorOverrides = {}) => {
+const createAppTheme = (colorOverrides = {}, feCoreConfig = {}) => {
   const {
     primaryColor,
     errorColor,
@@ -30,6 +30,10 @@ const createAppTheme = (colorOverrides = {}) => {
     toggledButtonColor,
     lockedBackgroundPattern,
   } = { ...defaultColors, ...colorOverrides };
+
+  const inputVariant = feCoreConfig?.Input?.variant
+    || feCoreConfig?.inputVariant
+    || "standard";
 
   const themeOptions = {
     breakpoints: {
@@ -52,13 +56,34 @@ const createAppTheme = (colorOverrides = {}) => {
         },
       },
       MuiTextField: {
-        defaultProps: { variant: "standard" },
+        defaultProps: { variant: inputVariant },
       },
       MuiSelect: {
-        defaultProps: { variant: "standard" },
+        defaultProps: { variant: inputVariant },
       },
       MuiFormControl: {
-        defaultProps: { variant: "standard" },
+        defaultProps: { variant: inputVariant },
+      },
+      MuiDatePicker: {
+        defaultProps: {
+          slotProps: {
+            textField: { variant: inputVariant },
+          },
+        },
+      },
+      MuiTimePicker: {
+        defaultProps: {
+          slotProps: {
+            textField: { variant: inputVariant },
+          },
+        },
+      },
+      MuiDateTimePicker: {
+        defaultProps: {
+          slotProps: {
+            textField: { variant: inputVariant },
+          },
+        },
       },
     },
     palette: {

--- a/src/helpers/theme.jsx
+++ b/src/helpers/theme.jsx
@@ -31,7 +31,7 @@ const createAppTheme = (colorOverrides = {}, feCoreConfig = {}) => {
     lockedBackgroundPattern,
   } = { ...defaultColors, ...colorOverrides };
 
-  const configuredVariant = feCoreConfig?.Input?.variant ?? feCoreConfig?.inputVariant;
+  const configuredVariant = feCoreConfig?.Input?.variant ;
   const normalizedVariant = typeof configuredVariant === "string" ? configuredVariant.toLowerCase() : undefined;
   const inputVariant = ["standard", "outlined", "filled"].includes(normalizedVariant) ? normalizedVariant : "standard";
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -125,8 +125,9 @@ const AppContainer = () => {
     initialize();
   }, []);
 
-  const themeColor = appState?.config?.["fe-core"]?.theme;
-  const dynamicTheme = createAppTheme(themeColor || {});
+  const feCoreConfig = appState?.config?.["fe-core"] || {};
+  const themeColor = feCoreConfig.theme;
+  const dynamicTheme = createAppTheme(themeColor || {}, feCoreConfig);
   const logo = getConfiguredLogo(appState.config);
   const disableTextLogo = appState?.config?.["fe-core"]?.logo?.disableTextLogo || false;
 


### PR DESCRIPTION
Allow users to set the default input variant (standard, outlined, filled) via `Input.variant` in the `fe-core` configuration. The variant is applied globally to MUI TextField, Select, FormControl, DatePicker, TimePicker, and DateTimePicker components. Update `createAppTheme` to accept the configuration and fall back to "standard" when not provided. Add documentation for the new configuration option.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to https://github.com/openimis/openimis-fe-core_js/pull/329
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
