### PR TITLE
fix: gate OpenSearch Dashboards on openIMIS rights and redirect to login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 REACT_APP_API_URL=api
 # OpenSearch proxy base root path
 OPENSEARCH_PROXY_ROOT="opensearch"
+# Credential nginx presents to OpenSearch Dashboards, base64 of "user:password".
+# Leave empty when the cluster runs with the security plugin disabled. Never
+# commit a real value - it is a credential, and nginx will not start if the
+# variable is unset rather than empty.
+OPENSEARCH_BASIC_TOKEN=""
 
 PUBLIC_URL=/front
 REACT_APP_API_URL=/api

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,8 @@ ENV REACT_APP_SENTRY_DSN=""
 ENV ROOT_MOBILEAPI="rest"
 ENV FORCE_RELOAD=""
 ENV OPENSEARCH_PROXY_ROOT="opensearch"
+# Needed even when empty: envsubst leaves unset vars literal, and nginx then
+# fails to start with 'unknown "opensearch_basic_token" variable'.
+ENV OPENSEARCH_BASIC_TOKEN=""
 ENTRYPOINT ["/bin/bash", "/script/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/conf/locations/opensearch.loc
+++ b/conf/locations/opensearch.loc
@@ -1,6 +1,21 @@
 
+    # Authorizes Dashboards against openIMIS rights, not merely a valid session.
+    # 200 right held, 403 right missing, 401 no session -> login.
+    location = /check_opensearch/ {
+        internal;
+        proxy_pass http://${backend}/${REACT_APP_API_URL}/opensearch_reports/auth_check;
+        proxy_method GET;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Original-URI $request_uri;
+    }
+
     location /opensearch/ {
-        auth_request /check_user/;
+        auth_request /check_opensearch/;
+        # auth_request can only deny; 403 passes through unchanged.
+        error_page 401 = @openimis_login;
+
         proxy_pass http://${opensearch};
         proxy_set_header   Host $host;
         proxy_set_header   X-Real-IP $remote_addr;
@@ -8,6 +23,9 @@
         proxy_set_header   X-Forwarded-Proto https;
         proxy_set_header   X-Forwarded-Host $server_name;
         proxy_set_header Authorization "Basic ${OPENSEARCH_BASIC_TOKEN}";
-    
+
     }
 
+    location @openimis_login {
+        return 302 /${PUBLIC_URL}/login;
+    }


### PR DESCRIPTION
## Problem

`conf/locations/opensearch.loc` gates `/opensearch/` on `auth_request /check_user/`, which calls `core/users/current_user/` — authentication only, no rights check. Any logged-in user reads every index.

Two secondary defects in the same path:

- No `error_page`, so an unauthenticated user gets a bare **401** inside the Dashboards iframe instead of being sent to login.
- `${OPENSEARCH_BASIC_TOKEN}` is used but documented nowhere — not in `.env.example`, no `ENV` default. `script/entrypoint.sh:13` builds the envsubst list from `printenv`, so an **unset** variable is left literal and nginx refuses to start:

  ```
  nginx: [emerg] unknown "opensearch_basic_token" variable
  ```

  That takes down the whole frontend container — SPA and `/api` proxy — not just Dashboards.

## Change

| Before | After |
|---|---|
| `auth_request /check_user/` -> `core/users/current_user/` | `auth_request /check_opensearch/` -> `opensearch_reports/auth_check` |
| 401 surfaces raw in the iframe | `error_page 401` -> `/${PUBLIC_URL}/login` |
| `OPENSEARCH_BASIC_TOKEN` undocumented, unset => nginx dies | `ENV OPENSEARCH_BASIC_TOKEN=""` + documented in `.env.example` |

`403` is deliberately **not** intercepted: redirecting an authenticated-but-unauthorized user to login would loop forever.

`/check_user/` is left in place — it is `internal` and referenced by nothing else here, but a deployment could add a `.loc` that uses it.

## Verification

Measured with the same backend and user data behind both configs:

| Case | `develop` | this branch |
|---|---|---|
| anonymous | 401, no redirect | 302 -> `/front/login` |
| logged in, no dashboard right | **200 (full access)** | 403 |
| user holding the right | 200 | 200 |

Config validated with `nginx -t` through the real `script/entrypoint.sh`, confirming `${REACT_APP_API_URL}`, `${PUBLIC_URL}` and `${OPENSEARCH_BASIC_TOKEN}` substitute while `${backend}`/`${opensearch}` correctly survive as nginx variables.

## Depends on

The `openimis-be-opensearch_reports_py` PR adding `auth_check`. Until it lands and is released into the assembly's pinned deps, this gate returns 401 for everyone.

## Known limitation

`return 302 /${PUBLIC_URL}/login` breaks if a deployment sets `PUBLIC_URL` with a leading slash — `//front/login` is protocol-relative. The Dockerfile default (`front`) is correct; `.env.example` uses `/front` for the Vite dev server. Worth normalising separately.
