### PR TITLE
fix: point the OpenSearch dev proxy at a reachable target

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import legacy from "@vitejs/plugin-legacy";
 import svgr from "vite-plugin-svgr";
@@ -144,10 +144,14 @@ export default defineConfig(({ mode }) => ({
         target: "http://localhost:8000",
         changeOrigin: true,
       },
+      // Point at an authorizing proxy with OPENSEARCH_PROXY_TARGET; the
+      // default reaches Dashboards directly.
       "/opensearch": {
-      target: "http://opensearch:5410",
-      changeOrigin: true,
-    }
+        target:
+          loadEnv(mode, ".", "").OPENSEARCH_PROXY_TARGET ||
+          "http://localhost:5601",
+        changeOrigin: true,
+      }
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
`vite.config.js` proxies `/opensearch` to `http://opensearch:5410` — a hostname that does not resolve from the host and a port that matches nothing in the deployment config. The repo's own nginx variable uses `opensearch-dashboards:5601`.

```js
target: process.env.OPENSEARCH_PROXY_TARGET || "http://localhost:5601",
```

Defaults to Dashboards on its published port. `OPENSEARCH_PROXY_TARGET` lets a developer route through an authorizing proxy instead, so local development can exercise the same authorization path as a deployment.

Note that `src/setupProxy.js` and the `proxies` block in `package.json` are webpack-dev-server conventions that Vite never reads; only `server.proxy` is live.
